### PR TITLE
Issue 16

### DIFF
--- a/CheckLinkCLI2/CheckLinkCLI2/FileReader.cs
+++ b/CheckLinkCLI2/CheckLinkCLI2/FileReader.cs
@@ -29,27 +29,19 @@ namespace CheckLinkCLI2
                                 foreach (var i in link.Split("\""))
                                 {
                                     if(i.StartsWith("http"))
-                                    {
                                         links.Add(i);
-
-                                    }
                                 }
                             }
                         }
-
                         else
-                        {
                             links.Add(sr.ReadLine());
-                        }
                     }
                     sr.Close();
                 }
             }
-
             else
-            {
                 links.Add("No file found!");
-            }
+
             return links;
         }
 
@@ -58,9 +50,7 @@ namespace CheckLinkCLI2
             foreach (var clo in commandLineOption)
             {
                 if (fileArg.Contains(clo))
-                {
                     return true;
-                }
             }
             return false;
         }
@@ -68,9 +58,7 @@ namespace CheckLinkCLI2
         private bool IsHtmlFile(string html)
         {
             if (html.Contains(".html"))
-            {
                 return true;
-            }
 
             return false;
 

--- a/CheckLinkCLI2/CheckLinkCLI2/Program.cs
+++ b/CheckLinkCLI2/CheckLinkCLI2/Program.cs
@@ -27,12 +27,24 @@ namespace CheckLinkCLI2
 
         #endregion
 
+        #region variables to test
         private static readonly string linkFile = @"absolutePathToTxtFile.txt";
-        private static readonly string htmlFile = @"absolutePathToHtmlFile.html";
+        private static readonly string htmlFile = @"D:\Documents\Seneca_College\OSD600\check-link2\check-link\CheckLinkCLI2\CheckLinkCLI2\index2.html";
+        #endregion
+
         public static readonly List<string> version = new List<string>() { "v", "-v", "version", "--version" };
+        //public static readonly List<string> json = new List<string>() { }
+        public static readonly List<string> supportFlags = new List<string>() { "--all", "--good", "--bad" };
+        //public static readonly Dictionary<int, string> supportFlags = new Dictionary<int, string>()
+        //{
+        //    { 0, "--all"},
+        //    { 1, "--good"},
+        //    { 2, "--bad"}
+        //};
         public static Dictionary<string, List<string>> CommandLineOptions = new Dictionary<string, List<string>>()
         {
-            {"version",version }
+            {"version",version },
+            //{"flag", supportFlags }
         };
 
         public static void Main(string[] args)
@@ -43,7 +55,6 @@ namespace CheckLinkCLI2
             #region Dev env
             if (IsDebug())
             {
-                //TODO: Search function that checks only one or few links on-demand
 
                 foreach (var input in args)
                 {
@@ -53,13 +64,15 @@ namespace CheckLinkCLI2
                         Console.WriteLine("\n");
                     }
 
+                    //else if (File.Exists(input) && (args.Contains<string>(supportFlags[0]) || args.Contains<string>(supportFlags[1]) || args.Contains<string>(supportFlags[2])))
                     else if (File.Exists(input))
                     {
-                        var links = FileReader.ExtractLinks(htmlFile);
-                        foreach (var link in links)
+                        foreach (var link in FileReader.ExtractLinks(htmlFile))
                         {
-                            LinkChecker.GetAllEndPointWithUri(link);
+                            string flag = LinkChecker.SetSupportFlag(args.Last<string>()) == null ? "--all" : LinkChecker.SetSupportFlag(args.Last<string>());
+                            LinkChecker.GetAllEndPointWithUri(link,flag);
                         }
+                        break;
                     }
 
                     else
@@ -109,6 +122,8 @@ namespace CheckLinkCLI2
                         {
                             if (File.Exists(file))
                             {
+                                // TODO: add the support flags here
+
                                 Console.Write("===|Reading file : ");
                                 Console.ForegroundColor = ConsoleColor.Cyan;
                                 Console.WriteLine($"{file}|===\n");
@@ -130,7 +145,7 @@ namespace CheckLinkCLI2
                                 Console.WriteLine($"{file}|===\n");
                                 Console.ResetColor();
                                 string[] files = Directory.GetFiles(file);
-                                foreach(string fileInDir in files)
+                                foreach (string fileInDir in files)
                                 {
                                     var links = FileReader.ExtractLinks(fileInDir);
                                     Console.Write("===|Reading file : ");
@@ -138,7 +153,7 @@ namespace CheckLinkCLI2
                                     Console.WriteLine($"{fileInDir}|===\n");
                                     Console.ResetColor();
                                     links.Sort();
-                                    foreach(var link in links)
+                                    foreach (var link in links)
                                     {
                                         LinkChecker.GetAllEndPointWithUri(link);
                                     }

--- a/CheckLinkCLI2/CheckLinkCLI2/Program.cs
+++ b/CheckLinkCLI2/CheckLinkCLI2/Program.cs
@@ -64,7 +64,6 @@ namespace CheckLinkCLI2
                         Console.WriteLine("\n");
                     }
 
-                    //else if (File.Exists(input) && (args.Contains<string>(supportFlags[0]) || args.Contains<string>(supportFlags[1]) || args.Contains<string>(supportFlags[2])))
                     else if (File.Exists(input))
                     {
                         foreach (var link in FileReader.ExtractLinks(htmlFile))
@@ -76,11 +75,8 @@ namespace CheckLinkCLI2
                     }
 
                     else
-                    {
                         Console.WriteLine($"File {input} does not exist");
-                    }
                 }
-
             }
             #endregion
 
@@ -132,7 +128,8 @@ namespace CheckLinkCLI2
                                 links.Sort();
                                 foreach (var link in links)
                                 {
-                                    LinkChecker.GetAllEndPointWithUri(link);
+                                    string flag = LinkChecker.SetSupportFlag(args.Last<string>()) == null ? "--all" : LinkChecker.SetSupportFlag(args.Last<string>());
+                                    LinkChecker.GetAllEndPointWithUri(link, flag);
                                 }
 
                                 Console.WriteLine("\n");
@@ -155,7 +152,8 @@ namespace CheckLinkCLI2
                                     links.Sort();
                                     foreach (var link in links)
                                     {
-                                        LinkChecker.GetAllEndPointWithUri(link);
+                                        string flag = LinkChecker.SetSupportFlag(args.Last<string>()) == null ? "--all" : LinkChecker.SetSupportFlag(args.Last<string>());
+                                        LinkChecker.GetAllEndPointWithUri(link, flag);
                                     }
 
                                     Console.WriteLine("\n");

--- a/CheckLinkCLI2/CheckLinkCLI2/WebLinkChecker.cs
+++ b/CheckLinkCLI2/CheckLinkCLI2/WebLinkChecker.cs
@@ -10,18 +10,18 @@ namespace CheckLinkCLI2
     public class WebLinkChecker
     {
         //initializing the default status code, which is always 0
-        private HttpStatusCode results = default(HttpStatusCode);
+        //private HttpStatusCode results = default(HttpStatusCode);
         public static long goodCounter, badCounter, unknownCounter = 0;
 
         /// <summary>
         /// Prints Good and Bad link to console
         /// </summary>
         /// <param name="url"></param>
-        public void GetAllEndPointWithUri(string url)
+        public void GetAllEndPointWithUri(string url, string supportFlag = "--all")
         {
             HttpClient httpClient = new HttpClient();
             httpClient.Timeout = TimeSpan.FromSeconds(2.5);
-            int? statusCode = null;
+            int? statusCode;
             try
             {
                 //TODO:
@@ -41,7 +41,7 @@ namespace CheckLinkCLI2
                 HttpStatusCode httpStatusCode = httpResponseMessage.StatusCode;
                 statusCode = (int)httpStatusCode;
                 httpClient.Dispose();
-                if (statusCode == 200)
+                if (statusCode == 200 && supportFlag != "--bad")
                 {
                     Console.ForegroundColor = ConsoleColor.Green;
                     Console.Write($"[{statusCode}] ");
@@ -51,9 +51,8 @@ namespace CheckLinkCLI2
                     Console.ForegroundColor = ConsoleColor.Green;
                     Console.WriteLine("Good");
                     goodCounter++;
-
                 }
-                else if (statusCode == 400 || statusCode == 404)
+                else if (statusCode == 400 || statusCode == 404 && supportFlag != "--good")
                 {
                     Console.ForegroundColor = ConsoleColor.Red;
                     Console.Write($"[{statusCode}] ");
@@ -104,5 +103,20 @@ namespace CheckLinkCLI2
             }
 
         }
+
+        /// <summary>
+        /// Returns Support Flag value
+        /// </summary>
+        /// <param name="flag"></param>
+        /// <returns></returns>
+        public string SetSupportFlag(string flag)
+        {
+            if (Program.supportFlags.Contains(flag))
+                return Program.supportFlags[Program.supportFlags.IndexOf(flag)];
+            else
+                return Program.supportFlags[0];
+        }
+
     }
+
 }

--- a/CheckLinkCLI2/CheckLinkCLI2/WebLinkChecker.cs
+++ b/CheckLinkCLI2/CheckLinkCLI2/WebLinkChecker.cs
@@ -52,7 +52,7 @@ namespace CheckLinkCLI2
                     Console.WriteLine("Good");
                     goodCounter++;
                 }
-                else if (statusCode == 400 || statusCode == 404 && supportFlag != "--good")
+                else if ((statusCode == 400 || statusCode == 404) && supportFlag != "--good")
                 {
                     Console.ForegroundColor = ConsoleColor.Red;
                     Console.Write($"[{statusCode}] ");
@@ -63,7 +63,7 @@ namespace CheckLinkCLI2
                     Console.WriteLine("Bad");
                     badCounter++;
                 }
-                else if (statusCode != null && statusCode != 400 && statusCode != 404 && statusCode != 200)
+                else if (statusCode != null && statusCode != 400 && statusCode != 404 && statusCode != 200 && supportFlag == "--all")
                 {
                     Console.ForegroundColor = ConsoleColor.Yellow;
                     Console.Write($"[{statusCode}] ");
@@ -78,7 +78,7 @@ namespace CheckLinkCLI2
             }
             catch (Exception e)
             {
-                if (e.InnerException.Message == "A task was canceled.")
+                if (e.InnerException.Message == "A task was canceled." && supportFlag != "--good")
                 {
                     Console.ForegroundColor = ConsoleColor.Red;
                     Console.Write("[404] ");
@@ -90,18 +90,18 @@ namespace CheckLinkCLI2
                     Console.ForegroundColor = ConsoleColor.Gray;
                     badCounter++;
                 }
-                else 
+                else
                 {
-                    Console.Write("[UKN] ");
-                    Console.Write($"{url} ");
-                    //Console.Write($"[{statusCode}] : ");
-                    Console.WriteLine(": Unknown");
-                    unknownCounter++;
+                    if (supportFlag == "--all")
+                    {
+                        Console.Write("[UKN] ");
+                        Console.Write($"{url} ");
+                        //Console.Write($"[{statusCode}] : ");
+                        Console.WriteLine(": Unknown");
+                        unknownCounter++;
+                    }
                 }
-                
-                
             }
-
         }
 
         /// <summary>


### PR DESCRIPTION
This PR resolved #16 . By passing `--good` or `--bad` or `--all` as an argument after the file path the program will display filtered information. For example: 

- `./CheckLinkCLI2.exe fileName --good` will return all links that have **200** status code
- `./CheckLinkCLI2.exe fileName --bad` will return all links that have **400** or **404** status code
- `./CheckLinkCLI2.exe fileName --all` will return all links that return any status code