### PR TITLE
Issue 17

### DIFF
--- a/CheckLinkCLI2/CheckLinkCLI2/CheckLinkCLI2.csproj
+++ b/CheckLinkCLI2/CheckLinkCLI2/CheckLinkCLI2.csproj
@@ -6,4 +6,8 @@
     <Configurations>Debug;Release;Deploy</Configurations>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+  </ItemGroup>
+
 </Project>

--- a/CheckLinkCLI2/CheckLinkCLI2/FileReader.cs
+++ b/CheckLinkCLI2/CheckLinkCLI2/FileReader.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿using CheckLinkCLI2.Models;
+using Newtonsoft.Json;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq.Expressions;
@@ -61,6 +63,32 @@ namespace CheckLinkCLI2
                 return true;
 
             return false;
+
+        }
+        /// <summary>
+        /// Receives file and writes it to a JSON file
+        /// </summary>
+        /// <param name="url"></param>
+        public void WriteToJSON(string file)
+        {
+            try
+            {
+                const string fileName = @"\CheckLinkCLI2JsonOutput.json";
+                WebLinkChecker lc = new WebLinkChecker();
+                var link = lc.GetLinkDetails(file);
+                var jsonToWrite = JsonConvert.SerializeObject(link, Formatting.Indented);
+                string path = Directory.GetCurrentDirectory() + fileName;
+                using (var writer = new StreamWriter(path))
+                {
+                    writer.Write(jsonToWrite);
+                }
+            }
+            catch (Exception)
+            {
+
+                throw;
+            }
+
 
         }
 

--- a/CheckLinkCLI2/CheckLinkCLI2/General/Utility.cs
+++ b/CheckLinkCLI2/CheckLinkCLI2/General/Utility.cs
@@ -1,0 +1,45 @@
+﻿using CheckLinkCLI2.Models;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace CheckLinkCLI2.General
+{
+    internal static class Utility
+    {
+        public static void ProgressBar(int progressCount, int totalCount)
+        {
+            //Draw empty progress bar
+            Console.CursorLeft = 0;
+            Console.Write("["); //start
+            Console.CursorLeft = 32;
+            Console.Write("]"); //end
+            Console.CursorLeft = 1;
+            float onechunk = 30.0f / totalCount;
+
+            //Draw filled part
+            int position = 1;
+            for (int i = 0; i <= onechunk * progressCount; i++)
+            {
+                Console.BackgroundColor = ConsoleColor.Green;
+                Console.CursorLeft = position++;
+                Console.Write(" ");
+                //if (progressCount == totalCount)
+                //    Console.CursorLeft = (int)(onechunk * progressCount);
+            }
+
+            //Draw unfilled part
+            for (int i = position; i <= 31; i++)
+            {
+                Console.BackgroundColor = ConsoleColor.Gray;
+                Console.CursorLeft = position++;
+                Console.Write(" ");
+            }
+
+            //Draw totals
+            Console.CursorLeft = 35;
+            Console.BackgroundColor = ConsoleColor.Black;
+            Console.Write(progressCount.ToString() + " of " + totalCount.ToString() + " links parsed    "); //blanks at the end remove any excess
+        }
+    }
+}

--- a/CheckLinkCLI2/CheckLinkCLI2/Models/Link.cs
+++ b/CheckLinkCLI2/CheckLinkCLI2/Models/Link.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Text;
+
+namespace CheckLinkCLI2.Models
+{
+    public class Link
+    {
+        [Key]
+        public int Id { get; set; }
+        public string Url { get; set; }
+        public int? StatusCode { get; set; }
+        public string LinkStatus { get; set; }
+    }
+}

--- a/CheckLinkCLI2/CheckLinkCLI2/Program.cs
+++ b/CheckLinkCLI2/CheckLinkCLI2/Program.cs
@@ -128,9 +128,10 @@ namespace CheckLinkCLI2
                             foreach (var link in FileReader.ExtractLinks(file))
                             {
                                 FileReader.WriteToJSON(file);
-                                Console.WriteLine($"\nResults of the links in {file} have been added to CheckLinkCLI2.json located in the current directory\n");
+                                Console.WriteLine($"\n\nResults of the links in {file} have been added to CheckLinkCLI2.json located in the current directory\n");
                                 break;
                             }
+                            break;
                         }
 
                         else

--- a/CheckLinkCLI2/CheckLinkCLI2/Program.cs
+++ b/CheckLinkCLI2/CheckLinkCLI2/Program.cs
@@ -33,7 +33,7 @@ namespace CheckLinkCLI2
         #endregion
 
         public static readonly List<string> version = new List<string>() { "v", "-v", "version", "--version" };
-        //public static readonly List<string> json = new List<string>() { }
+        public static readonly List<string> json = new List<string>() { "-j", @"\j", "--json" };
         public static readonly List<string> supportFlags = new List<string>() { "--all", "--good", "--bad" };
         //public static readonly Dictionary<int, string> supportFlags = new Dictionary<int, string>()
         //{
@@ -66,12 +66,21 @@ namespace CheckLinkCLI2
 
                     else if (File.Exists(input))
                     {
-                        foreach (var link in FileReader.ExtractLinks(htmlFile))
+                        if (!json.Contains(args.Last<string>()))
                         {
-                            string flag = LinkChecker.SetSupportFlag(args.Last<string>()) == null ? "--all" : LinkChecker.SetSupportFlag(args.Last<string>());
-                            LinkChecker.GetAllEndPointWithUri(link,flag);
+                            foreach (var link in FileReader.ExtractLinks(htmlFile))
+                            {
+                                string flag = LinkChecker.SetSupportFlag(args.Last<string>()) == null ? "--all" : LinkChecker.SetSupportFlag(args.Last<string>());
+                                LinkChecker.GetAllEndPointWithUri(link, flag);
+                            }
+                            break;
                         }
-                        break;
+                        else
+                        {
+                            FileReader.WriteToJSON(input);
+                            Console.WriteLine($"Results of the links in {input} have been added to CheckLinkCLI2.json located in the current directory");
+                            break;
+                        }
                     }
 
                     else
@@ -112,6 +121,16 @@ namespace CheckLinkCLI2
                         {
                             LinkChecker.GetAllEndPointWithUri(file);
                             Console.WriteLine("\n");
+                        }
+
+                        if (json.Contains(args.Last<string>()))
+                        {
+                            foreach (var link in FileReader.ExtractLinks(file))
+                            {
+                                FileReader.WriteToJSON(file);
+                                Console.WriteLine($"\nResults of the links in {file} have been added to CheckLinkCLI2.json located in the current directory\n");
+                                break;
+                            }
                         }
 
                         else


### PR DESCRIPTION
This is related to #17 . This PR adds the ability for CheckLinkCLI2 to output the results of the links into a JSON file. 
By simply adding any one of the flags `-j` or `\j` or `--json` after providing the file path, the program will parse through the file and added the results to a JSON file. 

![image](https://user-images.githubusercontent.com/36981880/95641122-7aed8980-0a6e-11eb-800e-f85815f3e82a.png)

For example, simply run `.\CheckLinkCLI2.exe fileName -j` will run this feature